### PR TITLE
[#6] Prevent multiple Coinbase account connections

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,7 +11,7 @@ module Users
       # same Coinbase account to a different CoinGenius accounts.
       # We want to avoid it
       if identity.user != current_user
-        redirect_to "/portfolio", alert: "You have already connected to Coinbase."
+        redirect_to "/portfolio", alert: "You have already connected to Coinbase using a different CoinGenius account."
       else
         # Update access and refresh tokens on every login (eg for a changed scopes)
         tokens = {


### PR DESCRIPTION
https://trello.com/c/Hc0GlXvd/6-give-error-message-when-multiple-accounts-try-to-oauth-with-the-same-coinbase-account

### Changes
- [x] Prevent connecting the same Coinbase account to a different Coingenius accounts