### PR TITLE
[5] - Sync Coinbase sells and buys from the all wallets

### DIFF
--- a/app/services/users/coinbase/create_transaction_from_buy.rb
+++ b/app/services/users/coinbase/create_transaction_from_buy.rb
@@ -1,0 +1,32 @@
+module Users
+  module Coinbase
+    # @param [::Coinbase::Wallet::Transfer] buy
+    # @param [User] user
+    class CreateTransactionFromBuy
+      include Interactor
+
+      delegate :user, :buy, to: :context
+
+      before do
+        next if buy["status"] != "completed" # Skip uncompleted transactions
+        next if ::Coinbase::Buy.where(uuid: buy["id"]).exists? # Or if we already processed this transaction
+      end
+
+      def call
+        ActiveRecord::Base.transaction do
+          context.transaction = user.transactions.create!(
+            amount: BigDecimal.new(buy["amount"]["amount"]),
+            coin: Coin.find_by(symbol: buy["amount"]["currency"]),
+            price: BigDecimal.new(buy["subtotal"]["amount"]) / BigDecimal.new(buy["amount"]["amount"]),
+            transaction_type: :bought
+          )
+
+          context.coinbase_buy = context.transaction.create_coinbase_buy!(
+            uuid: buy["id"],
+            raw_data: buy
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/users/coinbase/create_transaction_from_sell.rb
+++ b/app/services/users/coinbase/create_transaction_from_sell.rb
@@ -1,0 +1,32 @@
+module Users
+  module Coinbase
+    # @param [::Coinbase::Wallet::Transfer] sell
+    # @param [User] user
+    class CreateTransactionFromSell
+      include Interactor
+
+      delegate :user, :sell, to: :context
+
+      before do
+        next if sell["status"] != "completed" # Skip uncompleted transactions
+        next if ::Coinbase::Sell.where(uuid: sell["id"]).exists? # Or if we already processed this transaction
+      end
+
+      def call
+        ActiveRecord::Base.transaction do
+          context.transaction = user.transactions.create!(
+            amount: BigDecimal.new(sell["amount"]["amount"]),
+            coin: Coin.find_by(symbol: sell["amount"]["currency"]),
+            price: BigDecimal.new(sell["subtotal"]["amount"]) / BigDecimal.new(sell["amount"]["amount"]),
+            transaction_type: :sold
+          )
+
+          context.coinbase_sell = context.transaction.create_coinbase_sell!(
+            uuid: sell["id"],
+            raw_data: sell
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/services/users/coinbase/sync_buys_for_user.rb
+++ b/app/services/users/coinbase/sync_buys_for_user.rb
@@ -6,36 +6,16 @@ module Users
       delegate :user, to: :context
 
       def call
-        buys.each do |buy_transaction|
-          # Skip uncompleted transactions
-          next if buy_transaction["status"] != "completed"
+        client.accounts.each do |account|
+          buys = client.list_buys(account.id)
 
-          # Or if we already processed this transaction
-          next if ::Coinbase::Buy.where(uuid: buy_transaction["id"]).exists?
-
-          process_transaction(buy_transaction)
+          buys.each do |buy_transaction|
+            Users::Coinbase::CreateTransactionFromBuy.call(user: user, buy: buy_transaction)
+          end
         end
       end
 
       private
-
-      def process_transaction(buy_transaction)
-        transaction = user.transactions.create(
-          amount: BigDecimal.new(buy_transaction["amount"]["amount"]),
-          coin: Coin.find_by(symbol: buy_transaction["amount"]["currency"]),
-          price: BigDecimal.new(buy_transaction["subtotal"]["amount"]) / BigDecimal(buy_transaction["amount"]["amount"]),
-          transaction_type: :bought
-        )
-
-        transaction.create_coinbase_buy!(
-          uuid: buy_transaction["id"],
-          raw_data: buy_transaction
-        )
-      end
-
-      def buys
-        client.primary_account.list_buys
-      end
 
       def client
         @client ||= ::Coinbase::Wallet::OAuthClient.new(access_token: coinbase_identity.access_token)

--- a/app/services/users/coinbase/sync_sells_for_user.rb
+++ b/app/services/users/coinbase/sync_sells_for_user.rb
@@ -6,36 +6,16 @@ module Users
       delegate :user, to: :context
 
       def call
-        sells.each do |sell_transaction|
-          # Skip uncompleted transactions
-          next if sell_transaction["status"] != "completed"
+        client.accounts.each do |account|
+          sells = client.list_sells(account.id)
 
-          # Or if we already processed this transaction
-          next if ::Coinbase::Sell.where(uuid: sell_transaction["id"]).exists?
-
-          process_transaction(sell_transaction)
+          sells.each do |sell_transaction|
+            Users::Coinbase::CreateTransactionFromSell.call(user: user, sell: sell_transaction)
+          end
         end
       end
 
       private
-
-      def process_transaction(sell_transaction)
-        transaction = user.transactions.create!(
-          amount: BigDecimal.new(sell_transaction["amount"]["amount"]),
-          coin: Coin.find_by(symbol: sell_transaction["amount"]["currency"]),
-          price: BigDecimal.new(sell_transaction["subtotal"]["amount"]) / BigDecimal.new(sell_transaction["amount"]["amount"]),
-          transaction_type: :sold
-        )
-
-        transaction.create_coinbase_sell!(
-          uuid: sell_transaction["id"],
-          raw_data: sell_transaction
-        )
-      end
-
-      def sells
-        client.primary_account.list_sells
-      end
 
       def client
         @client ||= ::Coinbase::Wallet::OAuthClient.new(access_token: coinbase_identity.access_token)


### PR DESCRIPTION
https://trello.com/c/Rzoo4Iyb/5-allow-users-to-pull-transactions-from-non-primary-accounts-on-coinbase

### Changes
- [x] Extract processing sell and buy transactions to a separate services
- [x] Sync buys and sells from all wallets
