### PR TITLE
Eager load Bittrex from lib

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,6 @@ module Coingenius
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
 
-    config.autoload_paths += %W(#{config.root}/lib)
+    config.eager_load_paths += %W(#{config.root}/lib/bittrex)
   end
 end

--- a/lib/bittrex.rb
+++ b/lib/bittrex.rb
@@ -1,6 +1,0 @@
-module Bittrex
-  autoload :Client, "bittrex/client"
-  autoload :Deposit, "bittrex/deposit"
-  autoload :Order, "bittrex/order"
-  autoload :Withdrawal, "bittrex/withdrawal"
-end


### PR DESCRIPTION
In Rails 5 autoloading behavior changed. Code inside `lib` is not being eager loaded anymore.
There are two recomendations:
1. Use `/app/lib` to keep the code for auto loading
2. Put `/lib` to eager loaded paths

I chose the second option because `Bittrex` module is not a domain specific code, so we want to keep it outside `/app`

Fixes https://app.bugsnag.com/coingenius/rails/errors/59c1af82f967d00018ff2d87?filters%5Bevent.since%5D%5B%5D=30d&filters%5Berror.status%5D%5B%5D=new