### PR TITLE
Fix year formatting for beginning and end of the year

### DIFF
--- a/app/value_objects/formatted_year_and_week.rb
+++ b/app/value_objects/formatted_year_and_week.rb
@@ -1,29 +1,23 @@
 class FormattedYearAndWeek
-  WEEK_FORMAT = "%V".freeze
-  PREPEND_ZERO_FORMAT = "%02d".freeze
+  FORMAT = "%G-%V".freeze
 
   def initialize(time = Time.zone.now)
-    @year = time.year
-    @week = time.strftime(WEEK_FORMAT).to_i
+    @time = time
   end
 
   def value
-    @value ||= "#{year}-#{formatted_week(week)}"
+    @value ||= time.strftime(FORMAT)
   end
 
   def next
-    @next ||= "#{year}-#{formatted_week(week.next)}"
+    @next ||= (time + 1.week).strftime(FORMAT)
   end
 
   def previous
-    @previous ||= "#{year}-#{formatted_week(week.pred)}"
+    @previous ||= (time - 1.week).strftime(FORMAT)
   end
 
   private
 
-  attr_reader :year, :week
-
-  def formatted_week(week)
-    format(PREPEND_ZERO_FORMAT, week)
-  end
+  attr_reader :time
 end

--- a/spec/value_objects/formatted_year_and_week_spec.rb
+++ b/spec/value_objects/formatted_year_and_week_spec.rb
@@ -9,5 +9,25 @@ describe FormattedYearAndWeek do
       expect(value_object.next).to eq("2001-10")
       expect(value_object.previous).to eq("2001-08")
     end
+
+    context "when handling start of the year" do
+      let(:value_object) { described_class.new("01-01-2001".to_time) }
+
+      it "returns formatted year and date" do
+        expect(value_object.value).to eq("2001-01")
+        expect(value_object.next).to eq("2001-02")
+        expect(value_object.previous).to eq("2000-52")
+      end
+    end
+
+    context "when handling end of the year" do
+      let(:value_object) { described_class.new("31-12-2001".to_time) }
+
+      it "returns formatted year and date" do
+        expect(value_object.value).to eq("2002-01")
+        expect(value_object.next).to eq("2002-02")
+        expect(value_object.previous).to eq("2001-52")
+      end
+    end
   end
 end


### PR DESCRIPTION
There is an issue with incorrect handling for previous week for the first week of the year:
Previous week for `2018-01` was handled as `2018-01` instead of `2017-52`.